### PR TITLE
Fix[csv_display]:  on process display only when process completed

### DIFF
--- a/frontend/src/app/(app)/projects/[projectId]/processes/[processId]/page.tsx
+++ b/frontend/src/app/(app)/projects/[projectId]/processes/[processId]/page.tsx
@@ -130,6 +130,8 @@ export default function Process() {
     },
   ];
 
+  console.log("CSV:: ", process);
+
   return (
     <>
       <Head>
@@ -145,14 +147,16 @@ export default function Process() {
         </div>
       )}
 
-      <div className="pb-4">
-        <File
-          key={process?.id}
-          name={`${process?.name}.csv`}
-          type="spreadsheet"
-          onClick={() => handleFileClick(process)}
-        />
-      </div>
+      {process && process.status == ProcessStatus.COMPLETED && (
+        <div className="pb-4">
+          <File
+            key={process?.id}
+            name={`${process.name}.csv`}
+            type="spreadsheet"
+            onClick={() => handleFileClick(process)}
+          />
+        </div>
+      )}
 
       {isLoading ? (
         <PageLoader />

--- a/frontend/src/app/(app)/projects/[projectId]/processes/[processId]/page.tsx
+++ b/frontend/src/app/(app)/projects/[projectId]/processes/[processId]/page.tsx
@@ -130,8 +130,6 @@ export default function Process() {
     },
   ];
 
-  console.log("CSV:: ", process);
-
   return (
     <>
       <Head>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `File` component to only render when the process status is completed, ensuring users can download files only after the process is finished.

- **Bug Fixes**
	- Improved control flow for file downloads, preventing access when the process is not complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->